### PR TITLE
Build GITHUB_REPOSITORY and GITHUB_SHA into Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          GITHUB_REPOSITORY=${{ github.repository }}
+          GITHUB_SHA=${{ github.sha }}
     
     - name: Clear Untagged Images
       uses: actions/delete-package-versions@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,20 +47,6 @@ jobs:
         echo "Branch: $(cat $GITHUB_OUTPUT | grep BRANCH_NAME | cut -d'=' -f2)"
         echo "Image Tag: $(cat $GITHUB_OUTPUT | grep IMAGE_TAG | cut -d'=' -f2)"
     
-    - name: Set Deploy SHA
-      id: set-sha
-      run: |
-        if [[ "${{ inputs.environment }}" == "staging" ]]; then
-          # For staging, use current commit SHA
-          echo "DEPLOY_SHA=${{ github.sha }}" >> $GITHUB_OUTPUT
-        else
-          # For production/research, use main branch SHA
-          git fetch origin ${{ github.event.repository.default_branch }} --depth=1
-          MAIN_SHA=$(git rev-parse origin/${{ github.event.repository.default_branch }})
-          echo "DEPLOY_SHA=${MAIN_SHA}" >> $GITHUB_OUTPUT
-        fi
-        echo "Deploy SHA: $(cat $GITHUB_OUTPUT | grep DEPLOY_SHA | cut -d'=' -f2)"
-    
     - name: Pull Image
       uses: appleboy/ssh-action@v0.1.3
       with:
@@ -86,8 +72,6 @@ jobs:
           IMAGE_TAG,
           ENV,
           USER_ENCRYPTION_SALT,
-          GITHUB_REPOSITORY,
-          GITHUB_SHA,
           LOGFIRE_TOKEN,
           TELEGRAM_BOT_TOKEN,
           DEVELOPER_CHAT_ID,
@@ -111,8 +95,6 @@ jobs:
             -e PTB_TIMEDELTA="1" \
             -e ENV="$ENV" \
             -e USER_ENCRYPTION_SALT="$USER_ENCRYPTION_SALT" \
-            -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
-            -e GITHUB_SHA="$GITHUB_SHA" \
             -e LOGFIRE_TOKEN="$LOGFIRE_TOKEN" \
             -e TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
             -e DEVELOPER_CHAT_ID="$DEVELOPER_CHAT_ID" \
@@ -128,8 +110,6 @@ jobs:
       env:
         IMAGE_TAG: ${{ steps.set-tag.outputs.IMAGE_TAG }}
         ENV: ${{ inputs.environment }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_SHA: ${{ steps.set-sha.outputs.DEPLOY_SHA }}
         LOGFIRE_TOKEN: ${{ secrets.LOGFIRE_TOKEN }}
         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         USER_ENCRYPTION_SALT: ${{ secrets.USER_ENCRYPTION_SALT }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+ARG GITHUB_REPOSITORY
+ARG GITHUB_SHA
+
+ENV GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+ENV GITHUB_SHA=${GITHUB_SHA}
+
 COPY . .
 RUN uv sync --frozen
 


### PR DESCRIPTION
- Add ARG and ENV directives to Dockerfile to bake git metadata into image
- Pass build args in GitHub Actions build workflow
- Remove runtime env vars from deploy workflow since they're now in the image
- Remove unnecessary Set Deploy SHA step from deploy workflow

🤖 Generated with [Claude Code](https://claude.ai/code)