### PR TITLE
fix: Remove 'v' prefix from container tags and simplify cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,6 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ github.event.repository.name }}
         tags: |
           type=ref,event=branch,enable=${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
-          type=ref,event=tag
           # Semver aliases on tag builds (strips leading "v"):
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
@@ -66,12 +65,3 @@ jobs:
         package-type: 'container'
         token: ${{ secrets.GITHUB_TOKEN }}
         delete-only-untagged-versions: 'true'
-    
-    - name: Clear Inactive Images
-      if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-      uses: actions/delete-package-versions@v5
-      with:
-        package-name: ${{ github.event.repository.name }}
-        package-type: 'container'
-        token: ${{ secrets.GITHUB_TOKEN }}
-        min-versions-to-keep: '40'


### PR DESCRIPTION
## Summary
- Remove `type=ref,event=tag` from Docker metadata action to prevent duplicate container tags with 'v' prefix
- Remove "Clear Inactive Images" step since builds only occur on version tags
- Keep only untagged image cleanup for basic maintenance

🤖 Generated with [Claude Code](https://claude.ai/code)