### PR TITLE
Remove FastAPI linting rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ select = [
     "C4", # flake8-comprehensions
     "DTZ", # flake8-datetimez
     "E", # Pycodestyle
-    "FAST", # FastAPI
     "FBT", # flake8-boolean-trap
     "F", # Pyflakes
     "ICN", # import-convention


### PR DESCRIPTION
We don't use FastAPI in this repo so this rule seems unnecessary...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to streamline code quality checks. No impact on app behavior, performance, or UI.

* **No User-Facing Changes**
  * This release contains maintenance-only updates. Functionality, APIs, and user experience remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->