### PR TITLE
Refactor: Replace tg_context with tg_bot_id in agent dependencies

### DIFF
--- a/src/areyouok_telegram/jobs/conversations.py
+++ b/src/areyouok_telegram/jobs/conversations.py
@@ -267,7 +267,7 @@ class ConversationJob(BaseJob):
         notification = await self._get_next_notification()
 
         deps_data = {
-            "tg_context": self._run_context,
+            "tg_bot_id": str(self._bot_id),
             "tg_chat_id": self.chat_id,
             "tg_session_id": self.active_session.session_id,
             "notification": notification,

--- a/src/areyouok_telegram/llms/chat/agents/chat.py
+++ b/src/areyouok_telegram/llms/chat/agents/chat.py
@@ -7,7 +7,6 @@ from zoneinfo import ZoneInfoNotFoundError
 
 import pydantic_ai
 from pydantic_ai import RunContext
-from telegram.ext import ContextTypes
 
 from areyouok_telegram.data import Notifications
 from areyouok_telegram.data import UserMetadata
@@ -42,7 +41,7 @@ AgentResponse = TextResponse | ReactionResponse | SwitchPersonalityResponse | Do
 class ChatAgentDependencies:
     """Context data passed to the LLM agent for making decisions."""
 
-    tg_context: ContextTypes.DEFAULT_TYPE
+    tg_bot_id: str
     tg_chat_id: str
     tg_session_id: str
     personality: str = PersonalityTypes.COMPANIONSHIP.value
@@ -51,6 +50,7 @@ class ChatAgentDependencies:
 
     def to_dict(self) -> dict:
         return {
+            "tg_bot_id": self.tg_bot_id,
             "tg_chat_id": self.tg_chat_id,
             "tg_session_id": self.tg_session_id,
             "personality": self.personality,
@@ -127,7 +127,7 @@ async def validate_agent_response(
     await validate_response_data(
         response=data,
         chat_id=ctx.deps.tg_chat_id,
-        bot_id=str(ctx.deps.tg_context.bot.id),
+        bot_id=ctx.deps.tg_bot_id,
     )
 
     if ctx.deps.notification:

--- a/src/areyouok_telegram/llms/chat/agents/onboarding.py
+++ b/src/areyouok_telegram/llms/chat/agents/onboarding.py
@@ -9,7 +9,6 @@ from typing import Literal
 
 import pydantic_ai
 from pydantic_ai import RunContext
-from telegram.ext import ContextTypes
 
 from areyouok_telegram.data import GuidedSessions
 from areyouok_telegram.data import Notifications
@@ -46,7 +45,7 @@ AgentResponse = TextResponse | ReactionResponse | DoNothingResponse | KeyboardRe
 class OnboardingAgentDependencies:
     """Dependencies for the onboarding agent."""
 
-    tg_context: ContextTypes.DEFAULT_TYPE
+    tg_bot_id: str
     tg_chat_id: str
     tg_session_id: str
     onboarding_session_key: str
@@ -55,6 +54,7 @@ class OnboardingAgentDependencies:
 
     def to_dict(self) -> dict:
         return {
+            "tg_bot_id": self.tg_bot_id,
             "tg_chat_id": self.tg_chat_id,
             "tg_session_id": self.tg_session_id,
             "onboarding_session_key": self.onboarding_session_key,
@@ -256,7 +256,7 @@ async def validate_agent_response(
     await validate_response_data(
         response=data,
         chat_id=ctx.deps.tg_chat_id,
-        bot_id=str(ctx.deps.tg_context.bot.id),
+        bot_id=ctx.deps.tg_bot_id,
     )
 
     if ctx.deps.notification:

--- a/tests/test_jobs/test_conversations.py
+++ b/tests/test_jobs/test_conversations.py
@@ -100,7 +100,7 @@ class TestConversationJob:
                     return_value=(
                         [],
                         ChatAgentDependencies(
-                            tg_context=job._run_context,
+                            tg_bot_id="bot123",
                             tg_chat_id="123",
                             tg_session_id="session123",
                             personality="companionship",
@@ -142,7 +142,7 @@ class TestConversationJob:
         mock_payload.output = mock_response
 
         mock_deps = ChatAgentDependencies(
-            tg_context=job._run_context,
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -176,7 +176,7 @@ class TestConversationJob:
         job._bot_id = "bot123"
 
         mock_deps = ChatAgentDependencies(
-            tg_context=job._run_context,
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -425,7 +425,7 @@ class TestConversationJob:
                     return_value=(
                         [],
                         ChatAgentDependencies(
-                            tg_context=job._run_context,
+                            tg_bot_id="bot123",
                             tg_chat_id="123",
                             tg_session_id="session123",
                             personality="companionship",
@@ -486,7 +486,7 @@ class TestConversationJob:
                     return_value=(
                         [],
                         ChatAgentDependencies(
-                            tg_context=job._run_context,
+                            tg_bot_id="bot123",
                             tg_chat_id="123",
                             tg_session_id="session123",
                             personality="companionship",
@@ -521,7 +521,7 @@ class TestConversationJob:
         conversation_history = [mock_chat_event]
 
         mock_deps = ChatAgentDependencies(
-            tg_context=MagicMock(spec=ContextTypes.DEFAULT_TYPE),
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -548,7 +548,7 @@ class TestConversationJob:
         conversation_history = [mock_chat_event]
 
         mock_deps = ChatAgentDependencies(
-            tg_context=MagicMock(spec=ContextTypes.DEFAULT_TYPE),
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -574,7 +574,7 @@ class TestConversationJob:
 
         # Start with text in restricted responses and a notification
         mock_deps = ChatAgentDependencies(
-            tg_context=MagicMock(spec=ContextTypes.DEFAULT_TYPE),
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -623,7 +623,7 @@ class TestConversationJob:
                         (
                             [],
                             ChatAgentDependencies(
-                                tg_context=job._run_context,
+                                tg_bot_id="bot123",
                                 tg_chat_id="123",
                                 tg_session_id="session123",
                                 personality="companionship",
@@ -635,7 +635,7 @@ class TestConversationJob:
                         (
                             [],
                             ChatAgentDependencies(
-                                tg_context=job._run_context,
+                                tg_bot_id="bot123",
                                 tg_chat_id="123",
                                 tg_session_id="session123",
                                 personality="celebration",
@@ -1056,7 +1056,7 @@ class TestConversationJob:
         mock_notification.content = "Test notification content"
 
         mock_deps = ChatAgentDependencies(
-            tg_context=job._run_context,
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -1107,7 +1107,7 @@ class TestConversationJob:
         mock_notification.content = "Test notification content"
 
         mock_deps = ChatAgentDependencies(
-            tg_context=job._run_context,
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -1151,7 +1151,7 @@ class TestConversationJob:
 
         # Dependencies without notification
         mock_deps = ChatAgentDependencies(
-            tg_context=MagicMock(spec=ContextTypes.DEFAULT_TYPE),
+            tg_bot_id="bot123",
             tg_chat_id="123",
             tg_session_id="session123",
             personality="companionship",
@@ -1466,7 +1466,7 @@ class TestConversationJob:
                     return_value=(
                         [],
                         ChatAgentDependencies(
-                            tg_context=job._run_context,
+                            tg_bot_id="bot123",
                             tg_chat_id="123",
                             tg_session_id="session123",
                             personality="companionship",

--- a/tests/test_llms/test_chat/test_agents/test_chat.py
+++ b/tests/test_llms/test_chat/test_agents/test_chat.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest
 from freezegun import freeze_time
-from telegram.ext import ContextTypes
 
 from areyouok_telegram.data.models.notifications import Notifications
 from areyouok_telegram.data.models.user_metadata import UserMetadata
@@ -25,17 +24,16 @@ class TestChatAgentDependencies:
 
     def test_dependencies_creation_with_defaults(self):
         """Test ChatAgentDependencies creation with default values."""
-        tg_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
         tg_chat_id = "123456"
         tg_session_id = "session_123"
 
         deps = ChatAgentDependencies(
-            tg_context=tg_context,
+            tg_bot_id="bot123",
             tg_chat_id=tg_chat_id,
             tg_session_id=tg_session_id,
         )
 
-        assert deps.tg_context == tg_context
+        assert deps.tg_bot_id == "bot123"
         assert deps.tg_chat_id == tg_chat_id
         assert deps.tg_session_id == tg_session_id
         assert deps.personality == PersonalityTypes.COMPANIONSHIP.value
@@ -44,7 +42,6 @@ class TestChatAgentDependencies:
 
     def test_dependencies_creation_with_custom_values(self):
         """Test ChatAgentDependencies creation with custom values."""
-        tg_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
         tg_chat_id = "123456"
         tg_session_id = "session_123"
         personality = PersonalityTypes.ANCHORING.value
@@ -53,7 +50,7 @@ class TestChatAgentDependencies:
         mock_notification.content = "Special instruction"
 
         deps = ChatAgentDependencies(
-            tg_context=tg_context,
+            tg_bot_id="bot123",
             tg_chat_id=tg_chat_id,
             tg_session_id=tg_session_id,
             personality=personality,

--- a/tests/test_llms/test_chat/test_agents/test_onboarding.py
+++ b/tests/test_llms/test_chat/test_agents/test_onboarding.py
@@ -3,7 +3,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from telegram.ext import ContextTypes
 
 from areyouok_telegram.data.models.notifications import Notifications
 from areyouok_telegram.llms.chat.agents.onboarding import OnboardingAgentDependencies
@@ -15,16 +14,14 @@ class TestOnboardingAgentDependencies:
 
     def test_onboarding_agent_dependencies_creation(self):
         """Test OnboardingAgentDependencies can be created with required fields."""
-        mock_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
-
         deps = OnboardingAgentDependencies(
-            tg_context=mock_context,
+            tg_bot_id="bot123",
             tg_chat_id="123456789",
             tg_session_id="session_456",
             onboarding_session_key="onboarding_123",
         )
 
-        assert deps.tg_context == mock_context
+        assert deps.tg_bot_id == "bot123"
         assert deps.tg_chat_id == "123456789"
         assert deps.tg_session_id == "session_456"
         assert deps.onboarding_session_key == "onboarding_123"
@@ -33,10 +30,8 @@ class TestOnboardingAgentDependencies:
 
     def test_onboarding_agent_dependencies_with_restrictions(self):
         """Test OnboardingAgentDependencies with restricted responses."""
-        mock_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
-
         deps = OnboardingAgentDependencies(
-            tg_context=mock_context,
+            tg_bot_id="bot123",
             tg_chat_id="123456789",
             tg_session_id="session_456",
             onboarding_session_key="onboarding_123",
@@ -47,12 +42,11 @@ class TestOnboardingAgentDependencies:
 
     def test_onboarding_agent_dependencies_with_notification(self):
         """Test OnboardingAgentDependencies with notification."""
-        mock_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
         mock_notification = MagicMock(spec=Notifications)
         mock_notification.content = "Test notification"
 
         deps = OnboardingAgentDependencies(
-            tg_context=mock_context,
+            tg_bot_id="bot123",
             tg_chat_id="123456789",
             tg_session_id="session_456",
             onboarding_session_key="onboarding_123",
@@ -63,19 +57,15 @@ class TestOnboardingAgentDependencies:
 
     def test_onboarding_agent_dependencies_fields_required(self):
         """Test that required fields raise TypeError when missing."""
-        mock_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
-
         # Should raise TypeError if required fields are missing
         with pytest.raises(TypeError):
-            OnboardingAgentDependencies(tg_context=mock_context)  # Missing required fields
+            OnboardingAgentDependencies(tg_bot_id="bot123")  # Missing required fields
 
     def test_onboarding_agent_dependencies_validation(self):
         """Test OnboardingAgentDependencies field validation."""
-        mock_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
-
         # Should work with all required fields
         deps = OnboardingAgentDependencies(
-            tg_context=mock_context,
+            tg_bot_id="bot123",
             tg_chat_id="123456789",
             tg_session_id="session_456",
             onboarding_session_key="onboarding_123",
@@ -114,17 +104,15 @@ class TestOnboardingAgent:
 
     def test_onboarding_agent_dependencies_types(self):
         """Test that OnboardingAgentDependencies has correct types."""
-        mock_context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
-
         deps = OnboardingAgentDependencies(
-            tg_context=mock_context,
+            tg_bot_id="bot123",
             tg_chat_id="test_chat",
             tg_session_id="test_session",
             onboarding_session_key="test_key",
         )
 
         # Verify types
-        assert hasattr(deps, "tg_context")
+        assert hasattr(deps, "tg_bot_id")
         assert hasattr(deps, "tg_chat_id")
         assert hasattr(deps, "tg_session_id")
         assert hasattr(deps, "onboarding_session_key")


### PR DESCRIPTION
## Summary
Simplified LLM agent dependencies by replacing the full Telegram context object with just the bot ID string, reducing coupling and improving testability while maintaining full functionality.

## Changes Made
- **Core Refactoring**: Updated `ChatAgentDependencies` and `OnboardingAgentDependencies` to use `tg_bot_id: str` instead of `tg_context: ContextTypes.DEFAULT_TYPE`
- **Updated Usage**: Modified `conversations.py` to pass `str(self._bot_id)` instead of `self._run_context`
- **Maintained Functionality**: All validation and bot ID access points work exactly as before through `ctx.deps.tg_bot_id`
- **Test Updates**: Updated all test files to use the new dependency structure
- **Code Cleanup**: Removed unused imports and mock objects from test files

## Benefits
- **Reduced Coupling**: Agents no longer depend on the full Telegram framework context
- **Easier Testing**: Simplified dependency injection with just a string parameter
- **Better Separation**: Cleaner abstraction between Telegram framework and LLM agents
- **Maintained Compatibility**: All existing functionality preserved

## Files Modified
- `src/areyouok_telegram/llms/chat/agents/chat.py`
- `src/areyouok_telegram/llms/chat/agents/onboarding.py`
- `src/areyouok_telegram/jobs/conversations.py`
- `tests/test_jobs/test_conversations.py`
- `tests/test_llms/test_chat/test_agents/test_chat.py`
- `tests/test_llms/test_chat/test_agents/test_onboarding.py`

🤖 Generated with [Claude Code](https://claude.ai/code)