### PR TITLE
Disable parallel tool calls when using GPT5

### DIFF
--- a/src/areyouok_telegram/llms/agent_country_timezone.py
+++ b/src/areyouok_telegram/llms/agent_country_timezone.py
@@ -17,7 +17,7 @@ class CountryTimezone(pydantic.BaseModel):
 agent_model = GPT5Nano(
     model_settings=pydantic_ai.models.openai.OpenAIChatModelSettings(
         temperature=0.0,
-        parallel_tool_calls=True,
+        parallel_tool_calls=False,
         openai_reasoning_effort="minimal",
     )
 )

--- a/src/areyouok_telegram/llms/agent_preferences.py
+++ b/src/areyouok_telegram/llms/agent_preferences.py
@@ -38,7 +38,9 @@ class PreferencesUpdateResponse(pydantic.BaseModel):
 
 
 agent_model = GPT5Mini(
-    model_settings=pydantic_ai.models.openai.OpenAIChatModelSettings(openai_reasoning_effort="minimal")
+    model_settings=pydantic_ai.models.openai.OpenAIChatModelSettings(
+        openai_reasoning_effort="minimal", parallel_tool_calls=False
+    )
 )
 
 preferences_agent = pydantic_ai.Agent(

--- a/src/areyouok_telegram/llms/evaluators/personality_alignment.py
+++ b/src/areyouok_telegram/llms/evaluators/personality_alignment.py
@@ -18,6 +18,7 @@ agent_model = GPT5Mini(
     model_settings=pydantic_ai.models.openai.OpenAIChatModelSettings(
         temperature=0.0,
         openai_reasoning_effort="minimal",
+        parallel_tool_calls=False,
     )
 )
 

--- a/src/areyouok_telegram/llms/evaluators/reasoning_alignment.py
+++ b/src/areyouok_telegram/llms/evaluators/reasoning_alignment.py
@@ -17,6 +17,7 @@ agent_model = GPT5Mini(
     model_settings=pydantic_ai.models.openai.OpenAIChatModelSettings(
         temperature=0.0,
         openai_reasoning_effort="minimal",
+        parallel_tool_calls=False,
     )
 )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables parallel tool calls in OpenAIChatModelSettings for GPT5 agents across country timezone, preferences, and evaluation modules.
> 
> - **LLM configuration**:
>   - Set `parallel_tool_calls=False` in `OpenAIChatModelSettings` for:
>     - `src/areyouok_telegram/llms/agent_country_timezone.py` (`GPT5Nano`)
>     - `src/areyouok_telegram/llms/agent_preferences.py` (`GPT5Mini`)
>     - `src/areyouok_telegram/llms/evaluators/personality_alignment.py` (`GPT5Mini`)
>     - `src/areyouok_telegram/llms/evaluators/reasoning_alignment.py` (`GPT5Mini`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6746916ea7d40f887e2d04dfe88da434efa0a398. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted tool-call handling across agents and evaluators to run calls sequentially, improving stability and predictability during interactions.
  - Harmonized model settings for consistent behavior across preference, country/timezone, and evaluation flows.

- **Bug Fixes**
  - Reduced intermittent issues caused by overlapping tool invocations, leading to more reliable responses.

- **Chores**
  - Standardized configuration to align tool-call behavior across components without altering user-facing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->